### PR TITLE
Fix permission error in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ RUN apt install -y --no-install-recommends make gcc \
 	libx11-dev libxfixes-dev libxext-dev libxi-dev libxtst-dev libxrandr-dev \
 	libkrb5-dev libpam0g-dev \
 	libssl-dev libcap-dev
-
-RUN mkdir /home/vbridge && useradd vbridge && chown -R vbridge /home/vbridge
-USER vbridge
+RUN mkdir /home/vbridge
 
 COPY . /home/vbridge
 
+RUN useradd vbridge && chown -R vbridge /home/vbridge
+USER vbridge
+
 WORKDIR /home/vbridge
 RUN make
-


### PR DESCRIPTION
If you copy the sources after doing the chown, you may end up with
permission error when writing the binary.